### PR TITLE
fix not to format before invoke

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "langsmith_evaluation_helper"
 description = "Helper library for langsmith evalution"
-version = "0.1.3"
+version = "0.1.4"
 readme = "README.md"
 license = { file = "LICENSE" }
 

--- a/src/langsmith_evaluation_helper/load_run_function.py
+++ b/src/langsmith_evaluation_helper/load_run_function.py
@@ -69,9 +69,6 @@ def execute_prompt(
     else:
         raise ValueError(f"Invalid prompt type: {type(prompt)}")
 
-    messages = _prompt_template.format(**kwargs)
-    formatted_messages = PromptTemplate.from_template(messages)
-
     model_id = provider["id"]
     model = getattr(ChatModelName, model_id, None)
     provider_config = provider.get("config", {})
@@ -90,7 +87,8 @@ def execute_prompt(
         )
     else:
         raise ValueError(f"Invalid model_id: {model_id}")
-    result = llm.invoke(formatted_messages)
+
+    result = llm.invoke(_prompt_template, **kwargs)
     return result
 
 


### PR DESCRIPTION
since it was formatting before invoke, prompt that has escaping brackets was failing

ex:

```
{{"some_argument": hogehoge}}
```