### PR TITLE
enable adding metadata keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Defines the parameters for running tests on the conversation prompts.
 | `experiment_prefix`       | Prefix for naming experiments.                                      | `experiment_prefix: config_prompt_1` | Sets a prefix to distinguish experiments.                |
 | `max_concurrency`         | Number of tests or evaluations that can run concurrently.           | `max_concurrency: 4`                 | Determines how many tests can be run in parallel.        |
 | `num_repetitions`         | Specify how many times to run/evaluate each example in your dataset | `num_repetitions: 3`                 |                                                          |
+| `metadata_keys`         | Specify to add metadata from dataset examples | `metadata_keys:  - key1`                 |                                                          |
 | **`assert`**              | Specifies validation criteria for test results.                     |                                      |                                                          |
 | `type`                    | Type of assertion to validate the results.                          | `type: length`                       | Type of assertion                                        |
 | `value`                   | Defines the validation condition.                                   | `value: "<= 200"`                    | the condition of assertion metrics                       |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "langsmith_evaluation_helper"
 description = "Helper library for langsmith evalution"
-version = "0.1.4"
+version = "0.1.5"
 readme = "README.md"
 license = { file = "LICENSE" }
 

--- a/src/langsmith_evaluation_helper/loader.py
+++ b/src/langsmith_evaluation_helper/loader.py
@@ -29,24 +29,25 @@ def load_config(config_path: Any) -> dict[str, Any]:
     return config
 
 
-def load_dataset(config: dict[Any, Any]) -> tuple[Any, Any, Any]:
+def load_dataset(config: dict[Any, Any]) -> tuple[Any, Any, Any, list[str] | None]:
     test_info = config["tests"]
 
     dataset_name = test_info["dataset_name"]
     experiment_prefix = test_info["experiment_prefix"]
     num_repetitions = test_info.get("num_repetitions", 1)
+    metadata_keys = test_info.get("metadata_keys", [])
     split_string = test_info.get("split", None)
     limit = test_info.get("limit", None)
 
-    if split_string is None and limit is None:
-        return dataset_name, experiment_prefix, num_repetitions
+    if split_string is None and limit is None and len(metadata_keys) == 0:
+        return dataset_name, experiment_prefix, num_repetitions, metadata_keys
     limit = int(limit) if limit is not None else MAX_EXAMPLES_COUNT
 
     client = Client()
     examples = list(client.list_examples(dataset_name=dataset_name))
 
     if split_string is None and limit > 0:
-        return examples[:limit], experiment_prefix, num_repetitions
+        return examples[:limit], experiment_prefix, num_repetitions, metadata_keys
 
     splits = set(split_string.split(" "))
 
@@ -61,7 +62,7 @@ def load_dataset(config: dict[Any, Any]) -> tuple[Any, Any, Any]:
     test_examples = test_examples[:limit]
 
     if len(test_examples) > 0:
-        return (test_examples, experiment_prefix, num_repetitions)
+        return (test_examples, experiment_prefix, num_repetitions, metadata_keys)
     else:
         raise ValueError(f"No examples found for the dataset split: {split_string}")
 
@@ -81,6 +82,7 @@ async def run_evaluate(
     provider: dict[Any, Any],
     experiment_prefix: str,
     num_repetitions: int,
+    metadatas: dict[str, Any] | None,
     **kwargs: dict[str, Any],
 ) -> tuple[Any, Any]:
     experiment_prefix_provider = experiment_prefix + provider["id"]
@@ -88,12 +90,14 @@ async def run_evaluate(
 
     is_async = is_async_function(prompt_func)
 
+    metadata = {"prompt_version": "1"}
+    if metadatas:
+        metadata.update(metadatas)
+
     common_args = {
         "experiment_prefix": experiment_prefix_provider,
         "num_repetitions": num_repetitions,
-        "metadata": {
-            "prompt_version": "1",
-        },
+        "metadata": metadata,
         **kwargs,
     }
 
@@ -110,8 +114,26 @@ async def run_evaluate(
     return dataset_id, experiment_id
 
 
+def extract_metadata(dataset_examples: str | list[Any], metadata_keys: list[str]) -> dict[str, Any] | None:
+    if (
+        len(metadata_keys) == 0
+        or isinstance(dataset_examples, str)
+        or not dataset_examples
+        or dataset_examples[0].metadata is None
+    ):
+        return None
+
+    metadatas = {}
+    for key in metadata_keys:
+        if key in dataset_examples[0].metadata:
+            metadatas[key] = dataset_examples[0].metadata.get(key, None)
+
+    return metadatas if len(metadatas) > 0 else None
+
+
 async def main(config_file: dict[Any, Any]) -> None:
-    dataset_name, experiment_prefix, num_repetitions = load_dataset(config_file)
+    dataset_examples, experiment_prefix, num_repetitions, metadata_keys = load_dataset(config_file)
+    metadatas = extract_metadata(dataset_examples, metadata_keys)
     evaluators, summary_evaluators = load_evaluators(config_file)
     max_concurrency = config_file["tests"].get("max_concurrency", None)
     providers = config_file["providers"]
@@ -123,11 +145,12 @@ async def main(config_file: dict[Any, Any]) -> None:
         run_evaluate(
             provider,
             experiment_prefix,
-            data=dataset_name,
+            data=dataset_examples,
             evaluators=evaluators,
             summary_evaluators=summary_evaluators,
             max_concurrency=max_concurrency,
             num_repetitions=num_repetitions,
+            metadatas=metadatas,
         )
         for provider in providers
     ]

--- a/src/langsmith_evaluation_helper/loader.py
+++ b/src/langsmith_evaluation_helper/loader.py
@@ -29,7 +29,7 @@ def load_config(config_path: Any) -> dict[str, Any]:
     return config
 
 
-def load_dataset(config: dict[Any, Any]) -> tuple[Any, Any, Any, list[str] | None]:
+def load_dataset(config: dict[Any, Any]) -> tuple[Any, Any, Any, list[str]]:
     test_info = config["tests"]
 
     dataset_name = test_info["dataset_name"]

--- a/tests/langsmith_evaluation_helper/config_input.py
+++ b/tests/langsmith_evaluation_helper/config_input.py
@@ -252,6 +252,28 @@ class Configurations:
             dataset_name: Toxic Queries
             experiment_prefix: config_prompt_1
         """,
+        "with_metadata": """
+        description: Testing load_dataset with metadata keys
+
+        evaluators_file_path: test_evaluation1.py
+
+        prompt:
+          name: prompt.py
+          type: python
+          entry_function: test_function1
+
+        providers:
+          - id: Model1
+            config:
+              temperature: 0.7
+
+        tests:
+            dataset_name: Toxic Queries
+            experiment_prefix: config_prompt_1
+            metadata_keys:
+              - key1
+              - key2
+        """,
         "integration_loader": """
         description: End to end integration test
 

--- a/tests/langsmith_evaluation_helper/test_loader.py
+++ b/tests/langsmith_evaluation_helper/test_loader.py
@@ -114,13 +114,17 @@ def test_load_dataset(
     test_info = config_file["tests"]
     split_string = test_info.get("split", None)
     limit = test_info.get("limit", None)
-    dataset_output, experiment_prefix, _ = load_dataset(config_file)
+    dataset_output, experiment_prefix, _, metadata_keys = load_dataset(config_file)
 
     # Testing for no-split, no-limit
     expected_dataset_name = test_info["dataset_name"]
     expected_experiment_prefix = test_info["experiment_prefix"]
-    if split_string is None and limit is None:
+    if split_string is None and limit is None and len(metadata_keys) == 0:
         assert dataset_output == expected_dataset_name
+        assert experiment_prefix == expected_experiment_prefix
+
+    if split_string is None and limit is None and len(metadata_keys) > 0:
+        assert dataset_output == response_examples
         assert experiment_prefix == expected_experiment_prefix
 
     mocked_examples = response_examples
@@ -171,6 +175,7 @@ async def test_main(
         "dataset_name",
         "experiment_prefix",
         "num_repititions",
+        [],
     )
     mock_load_evaluators.return_value = (["evaluator1"], ["summary_evaluator1"])
     mock_run_evaluate.return_value = ("dataset_id", "experiment_id")


### PR DESCRIPTION
enable passing metadata from dataset example.
this enables passing same metadata value to experiment run