### PR TITLE
Make unit tests runnable without API keys

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,29 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from collections.abc import Callable
 from pathlib import Path
 
 import pytest
 
 # Assuming Configurations.get_all_configs(), MockClient, response_examples, load_config, and load_dataset are defined elsewhere
+
+# Placeholder credentials so unit tests can construct provider clients without real keys.
+PLACEHOLDER_API_KEYS = {"OPENAI_API_KEY": "sk-unit-test"}
+
+
+@pytest.fixture(autouse=True)
+def placeholder_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fill in placeholder API keys for any provider credential that is not already set.
+
+    Clients such as `ChatOpenAI` and `OpenAIEmbeddings` validate their API key at construction
+    time, so unit tests that never make a request would still fail without one. Real values (from
+    `.env` or CI secrets) are left untouched so `integration_test` tests keep hitting the providers.
+    """
+    for name, placeholder in PLACEHOLDER_API_KEYS.items():
+        if not os.getenv(name):
+            monkeypatch.setenv(name, placeholder)
 
 
 @pytest.fixture(scope="session")

--- a/tests/langsmith_evaluation_helper/test_generate_builtin_evaluator_functions.py
+++ b/tests/langsmith_evaluation_helper/test_generate_builtin_evaluator_functions.py
@@ -100,7 +100,13 @@ def test_llm_judge_evaluator_logic(
 
 
 @pytest.mark.parametrize("config", Configurations.get_config("multiple_asserts"))
-def test_similar_evaluator(config: str, create_temp_config_file: Callable[[str], Path]) -> None:
+@mock.patch(
+    "langchain_openai.OpenAIEmbeddings.embed_documents",
+    return_value=[[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+)
+def test_similar_evaluator(
+    mock_embed_documents: mock.MagicMock, config: str, create_temp_config_file: Callable[[str], Path]
+) -> None:
     config_file_path = create_temp_config_file(config)
     config_file = load_config(str(config_file_path))
     config_file["tests"].get("assert", [])
@@ -112,3 +118,4 @@ def test_similar_evaluator(config: str, create_temp_config_file: Callable[[str],
     result = evaluator(run, example)
 
     assert isinstance(result, EvaluationResult | EvaluationResults)  # type: ignore
+    mock_embed_documents.assert_called_once()


### PR DESCRIPTION
## Problem

Every Dependabot PR fails CI (e.g. #54), and has done for the last 60+ runs. The failure is always the same 2 tests, and it has nothing to do with the dependency being bumped.

GitHub does not expose Actions secrets to workflows triggered by Dependabot pull requests — the `secrets` context is populated from Dependabot secrets instead, which aren't configured for this repo. So `OPENAI_API_KEY` reaches `make unit_test` as an empty string.

Two tests then fail, because they build real LangChain OpenAI clients that validate the API key at construction time:

- `test_llm_judge_evaluator_logic` mocks `ChatModel.invoke` but not the constructor, so `ChatOpenAI` is still instantiated.
- `test_similar_evaluator` goes further and makes an actual embeddings request via `LangChainStringEvaluator("embedding_distance")`.

Both raise `ValidationError: Did not find openai_api_key`. These were effectively integration tests sitting in the unit test suite, passing only because a real key happened to be in the environment.

## Solution

Make the unit test suite independent of credentials, rather than papering over it by supplying a key to Dependabot.

- An autouse fixture in `tests/conftest.py` fills in a placeholder `OPENAI_API_KEY` only when it isn't already set. Real values from `.env` or CI secrets are left alone, so `integration_test` marked tests still hit the real providers.
- `test_similar_evaluator` now mocks `OpenAIEmbeddings.embed_documents`, so it exercises the evaluator wiring without a network call.

## Verification

With every provider credential stripped from the environment — the exact condition of a Dependabot run:

```
env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u AZURE_OPENAI_API_KEY pytest -m "not integration_test"
→ 45 passed, 2 deselected
```

Previously this gave `2 failed, 43 passed`.

## Note

Once this is on `main`, the open Dependabot PRs need a rebase (`@dependabot rebase`) before their CI picks up the fix.