### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "langsmith_evaluation_helper"
 description = "Helper library for langsmith evalution"
-version = "0.1.5"
+version = "0.1.7"
 readme = "README.md"
 license = { file = "LICENSE" }
 


### PR DESCRIPTION
Prepares the v0.1.7 release.

`pyproject.toml` was never bumped for v0.1.6 — it still declared `0.1.5`, so the publish workflow built a version that already existed on PyPI and the release never landed there. PyPI's latest is still `0.1.5`.

This bumps straight to `0.1.7` so the tag, the built artifact and PyPI all agree. `0.1.6` stays as a GitHub-only tag.