### PR TITLE
Route Claude models correctly and drop retired models from integration tests

### DIFF
--- a/src/langsmith_evaluation_helper/llm/model.py
+++ b/src/langsmith_evaluation_helper/llm/model.py
@@ -27,14 +27,31 @@ class ChatModelName(Enum):
     GEMINI_PRO = "gemini-pro"
     GEMINI_FLASH = "gemini-1.5-flash-001"
     GEMINI_2_FLASH = "gemini-2.0-flash"
-    CLAUDE3_SONNET = "claude3-sonnet"
+    CLAUDE3_SONNET = "claude-3-sonnet-20240229"
     CLAUDE3_OPUS = "claude-3-opus-20240229"
     CLAUDE3_HAIKU = "claude-3-haiku-20240307"
     CLAUDE3_5_SONNET = "claude-3-5-sonnet-20240620"
+    CLAUDE_OPUS_5 = "claude-opus-5"
+    CLAUDE_SONNET_5 = "claude-sonnet-5"
+    CLAUDE_HAIKU_4_5 = "claude-haiku-4-5-20251001"
 
 
 AZURE_OPENAI_API_KEY = os.getenv("AZURE_OPENAI_API_KEY", "")
 AZURE_OPENAI_API_BASE = os.getenv("AZURE_OPENAI_API_BASE", "")
+
+# Claude 3 models have reached end of life and the API rejects requests for them.
+LEGACY_CLAUDE_MODELS = {
+    ChatModelName.CLAUDE3_SONNET,
+    ChatModelName.CLAUDE3_OPUS,
+    ChatModelName.CLAUDE3_HAIKU,
+    ChatModelName.CLAUDE3_5_SONNET,
+}
+
+CLAUDE_MODELS = LEGACY_CLAUDE_MODELS | {
+    ChatModelName.CLAUDE_OPUS_5,
+    ChatModelName.CLAUDE_SONNET_5,
+    ChatModelName.CLAUDE_HAIKU_4_5,
+}
 
 
 def get_chat_model(name: ChatModelName, **kwargs: Any) -> BaseChatModel:
@@ -71,13 +88,16 @@ def get_chat_model(name: ChatModelName, **kwargs: Any) -> BaseChatModel:
             model_name=name.value,
             **kwargs,
         )
-    elif (
-        name == ChatModelName.CLAUDE3_SONNET
-        or name == ChatModelName.CLAUDE3_OPUS
-        or name == ChatModelName.CLAUDE3_HAIKU
-        or name == ChatModelName.CLAUDE3_5_SONNET
-    ):
-        return ChatAnthropic(model_name="claude-3-sonnet-20240229", **kwargs)
+    elif name in CLAUDE_MODELS:
+        if name in LEGACY_CLAUDE_MODELS:
+            warnings.warn(
+                f"{name.name} has reached end of life and the Anthropic API no longer serves it. "
+                "Use CLAUDE_OPUS_5, CLAUDE_SONNET_5 or CLAUDE_HAIKU_4_5 instead. "
+                "see details: https://docs.claude.com/en/docs/about-claude/model-deprecations",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return ChatAnthropic(model_name=name.value, **kwargs)
     else:
         raise ValueError(f"Invalid model name. {name}")
 

--- a/tests/langsmith_evaluation_helper/config_input.py
+++ b/tests/langsmith_evaluation_helper/config_input.py
@@ -210,7 +210,7 @@ class Configurations:
           - id: TURBO
             config:
               temperature: 0.7
-          - id: GPT4
+          # - id: GPT4  # gpt-4-0613 is retired
           - id: GPT4O
           - id: AZURE_GPT35_16K_TURBO
             config:
@@ -219,10 +219,9 @@ class Configurations:
               azure_api_version: 2023-08-01-preview
           # - id: GEMINI_PRO
           # - id: GEMINI_FLASH
-          - id: CLAUDE3_SONNET
-          - id: CLAUDE3_OPUS
-          - id: CLAUDE3_HAIKU
-          - id: CLAUDE3_5_SONNET
+          # Claude 3 models are retired; see LEGACY_CLAUDE_MODELS in llm/model.py
+          - id: CLAUDE_SONNET_5
+          - id: CLAUDE_HAIKU_4_5
 
 
 


### PR DESCRIPTION
Prep for the v0.1.7 release. The release workflow gates the PyPI upload behind `make integration_test`, and those tests currently call models the providers no longer serve.

## The routing bug

`get_chat_model` hardcoded a single model id for the entire Claude branch:

```python
return ChatAnthropic(model_name="claude-3-sonnet-20240229", **kwargs)
```

So `CLAUDE3_OPUS`, `CLAUDE3_HAIKU` and `CLAUDE3_5_SONNET` all silently issued requests as Claude 3 Sonnet — selecting a model did nothing. Related: `CLAUDE3_SONNET` was defined as `"claude3-sonnet"`, which is not a valid model id, and only worked because the value was never used.

Now the enum value is passed through, so the value has to be right, and it is.

## Changes

- `ChatAnthropic` receives `name.value` instead of a hardcoded id, and `CLAUDE3_SONNET` is corrected to `claude-3-sonnet-20240229`.
- Added `CLAUDE_OPUS_5`, `CLAUDE_SONNET_5` and `CLAUDE_HAIKU_4_5`.
- The Claude 3 members are kept for compatibility but now emit a `DeprecationWarning`, matching the existing pattern for legacy Gemini models.
- The `multi-providers-all` integration config drops `GPT4` (`gpt-4-0613`, retired) and the Claude 3 entries, and exercises `CLAUDE_SONNET_5` / `CLAUDE_HAIKU_4_5` instead.

## Verification

Unit tests pass (45 passed, 2 deselected) with all provider credentials stripped.

**The integration tests are not verified** — they need real provider credentials, which I don't have locally. That path only runs when the `v*` tag fires `release.yml`. The Azure entry (`gpt-35-turbo-16k-dev`) is left untouched since I can't tell whether that deployment still exists.